### PR TITLE
update install method to pip

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,11 +13,12 @@ source:
 
 build:
   number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
     - python
+    - pip
     - setuptools
   run:
     - python


### PR DESCRIPTION
following the [coda-forge recommendations](https://github.com/conda-forge/staged-recipes#7-when-or-why-do-i-need-to-use-python--m-pip-install---no-deps---ignore-installed-), switch to installing the package via `pip install` rather than `setup.py`